### PR TITLE
Strip whitespace from CSV header keys

### DIFF
--- a/lib/pangrid/plugins/csv.rb
+++ b/lib/pangrid/plugins/csv.rb
@@ -40,7 +40,7 @@ class CSV < Plugin
     h = s.shift.map {|c| c.split(/:\s*/)}
     header = OpenStruct.new
     h.each do |k, v|
-      header[k.downcase] = v
+      header[k.downcase.strip] = v
     end
 
     header.clues = header.clues.to_i


### PR DESCRIPTION
The [comments for the CSV reader plugin](https://github.com/martindemello/pangrid/blob/master/lib/pangrid/plugins/csv.rb#L7) suggest the following header format for a CSV:

```
Width: 15, Height: 15, Offset: 0, Black: ., Empty: -, Clues: 3
```

When I tried this in my CSV, I kept getting a `Extra down clue (Pangrid::PuzzleFormatError)` since the leading whitespace before the header keys (e.g. `.., Height,...`) was preventing those values from getting written to the class's `header` struct.

Stripping the whitespace from the keys fixes the issue. This might prevent confusion for a future user so I thought I'd submit a quick fix! Thanks a lot for taking the time to put this project together - it's really cool and useful!